### PR TITLE
Dockerize this example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+#
+# Docker container for the node sender
+#
+# node:argon does not install node inspector properly with install -g
+# fails on a v8 package, use glen's insteadj
+#FROM glenschler/nodejs-inspector:4
+# To run on rpi
+# FROM resin/rpi-node:argon
+FROM node:argon
+#FROM glenschler/nodejs-inspector:4
+MAINTAINER Rich Tong (rich@surround.io)
+ENV DEBIAN_FRONTEND=noninteractive
+EXPOSE 3000
+# node inspector debugging port
+EXPOSE 5858 8080
+
+# Need vim for debugging
+# https://spin.atomicobject.com/2015/09/25/debug-node-js/
+RUN apt-get update -y && \
+    apt-get install -y \
+        vim
+
+# Yeoman has does not want to be run as root and will fail
+# It sets itself to UID 501 arbitrarily if it detects root
+# https://github.com/yeoman/yeoman.github.io/issues/282
+# https://github.com/krakenjs/generator-kraken/issues/114#issuecomment-54201366
+# So you must run this in a different user context
+# generated with npm init and then npm installs
+# http://stackoverflow.com/questions/27701930/add-user-to-docker-container
+# And this creates a new problem since yo tries to create global modules
+# without sudo access so we need to open up permissions enough so that a 
+# non-sudo user can add things properly in node and also to create the yo
+# command
+RUN chmod 777 /usr/local/lib/node_modules /usr/local/bin
+RUN useradd -ms /bin/bash node 
+USER node
+WORKDIR /home/node
+
+# Need .babelrc so babel knows what languages to compile
+COPY package.json webpack.config.js ./
+# Note if you just do COPY src ./ then it will copy all contents of src into the
+# top 
+COPY src src/
+
+RUN npm install
+
+# Using jhs-webpack so need to call it from there
+# If you want to debug then run `make debug` and this command will not be run
+CMD npm start

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+# Remember makefile *must* use tabs instead of spaces so use this vim line
+# vi: set tabstop=4 shiftwidth=4 noexpandtab 
+#
+# Still have issues with stale images
+#
+# change the variables here
+repo ?= surround
+name ?= $$(basename "$(PWD)")
+Dockerfile ?= Dockerfile
+image ?= $(repo)/$(name)
+container = $(name)
+data ?= /var/media
+destination ?= $(HOME)/ws/runtime
+# the user name on the host nodes if a raspberry pi
+user ?= node
+
+# /dev/video0 needed for v4l2
+# /dev/vchiq needed for mmal
+# Punch the image directory out to the host. We are doing this because docker cp
+# is way too slow
+# port 5858 is the node debug port
+# For some reason the src mapping no long works you cannot map
+# -v $(PWD)/src:/home/$(user)/src 
+flags ?= -p 8080:8080 -p 3000:3000 -p 5858:5858 
+
+include surround.mk

--- a/README.md
+++ b/README.md
@@ -1,7 +1,44 @@
-## Up and running with ES6 and React in under 5 minutes
+Up and running ES6 and React in under 6 minutes
+===============================================
+Here is the command set to run ES6 and React natively:
 
-* Clone the repo
-* `npm i`
-* `npm start`
-* Open [http://localhost:3000](http://localhost:3000)
-* Edit the source to see hot reloading in action
+- Clone the repository
+
+```
+npm install
+npm start
+```
+
+Now you can open `http://localhost:3000` and edit the source and it will hot
+reload
+
+
+Running under docker
+===================
+You can use a prebuilt docker image with and also prebuilt make file which makes
+docker pulls and so forth
+
+```
+docker build -t <your repo>/egghead-hjs-webpack-demo .
+docker run -dt -p 3000:3000 <your repo>/egghead-hjs-webpack-demo 
+```
+
+
+If you want to just use a prebuilt container then you can use:
+
+```
+docker run -dt -p 3000:3000 surround/egghead-jhs-webpack-demo
+```
+
+Then you can open `http://localhost:3000`
+
+Explanation
+-----------
+http://stackoverflow.com/questions/33462123/connecting-webpack-dev-server-inside-a-docker-container-from-the-host
+clarifies that what is happening is that it is running by default in iframe
+mode, so you have get to it with `http://localhost:3000/webpack-dev-server/index.html`
+
+If you want inline mode then you need to add `--inline` to the invocation and
+then the `http://localhost:3000/index.html` works and this is what is the
+package.json
+

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "stage": 0
   },
   "scripts": {
-    "start": "webpack-dev-server --host 0.0.0.0 --inline",
+    "start": "webpack-dev-server --host 0.0.0.0 --inline --hot",
     "build": "webpack",
     "deploy": "npm run build && surge -p public -d somedomain.com"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "stage": 0
   },
   "scripts": {
-    "start": "webpack-dev-server",
+    "start": "webpack-dev-server --host 0.0.0.0 --inline",
     "build": "webpack",
     "deploy": "npm run build && surge -p public -d somedomain.com"
   },

--- a/surround.mk
+++ b/surround.mk
@@ -1,0 +1,1 @@
+../src/infra/rpi/docker/surround.mk


### PR DESCRIPTION
This adds --host 0.0.0.0 and --inline to the npm start script. Both are necessary because the docker container network needs to be accessible outside the container. Also in this mode, the webpack-dev-server switches to iframe mode (http://localhost:3000/webpack-dev-server/index.html) and you need --inline to make it work on `http://localhost:3000`

Also updated the README.md to reflect how to make it run in the docker container.
